### PR TITLE
BMS

### DIFF
--- a/bms.c
+++ b/bms.c
@@ -1,0 +1,305 @@
+#include <stdio.h>
+#include "bms.h"
+#include <stdlib.h>
+
+/**************************************************************************
+* 	REVISION HISTORY:
+*
+*
+*	2016-4-7 - Rabeel Elahi - Created this file.
+*							- Defined cases for BMS can messages
+*							- Helper functions commented out; 
+*							  directly modifying variables via ptrs instead
+*							- TODO: Rename variable types to VCU types
+*							- TODO: Move canInput_readMesagges to caninput.c
+*							- TODO: Move ENDIAN conversion functions to caninput.c?
+*
+*
+**************************************************************************/
+
+/**********************************************************
+ *	 	 	 *********** CAUTION ***********              *
+ * MULTI-BYTE VALUES FOR THE ELITHION BMS ARE BIG-ENDIAN  *
+ *														  *
+ **********************************************************/
+
+
+
+struct _BMS{
+
+	uint16_t canMessageBaseId;
+
+	// 0x622h //
+
+	uint8_t  state; 			// state of system
+	uint16_t timer;				// power up time
+	uint8_t  flags;				// flags
+	uint8_t  faultCode; 		// fault code, stored
+	uint8_t  levelFaults;		// Level fault flags (e.g. over voltage, under voltage, etc)
+	uint8_t  warnings;			// warning flags
+
+	// 0x623h //
+
+	uint16_t packVoltage;		// Total voltage of pack
+	uint8_t  minVtg;			// Voltage of least charged cell
+	uint8_t  minVtgCell;     	// ID of cell with lowest voltage
+	uint8_t  maxVtg;			// Voltage of most charged cell
+	uint8_t  maxVtgCell;     	// ID of cell with highest voltage
+
+	// 0x624h //
+
+	int16_t  packCurrent;		// Pack current
+	uint16_t chargeLimit;		// Maximum current acceptable (charge)
+	uint16_t dischargeLimit;	// Maximum current available (discharge)
+
+	// 0x625h //
+
+	uint32_t batteryEnergyIn; 	// Total energy into battery
+	uint32_t batteryEnergyOut;	// Total energy out of battery
+
+
+	// 0x626h //
+
+	uint8_t  SOC; 				// state of charge
+	uint16_t DOD; 				// depth of discharge
+	uint16_t capacity; 			// actual capacity of pack
+	uint8_t  SOH;				// State of Health
+
+	// 0x627h //
+
+	int8_t  packTemp;			// average pack temperature
+	int8_t  minTemp;			// Temperature of coldest sensor
+	int8_t  minTempCell; 		// ID of cell with lowest temperature
+	int8_t  maxTemp;			// Temperature of hottest sensor
+	int8_t  maxTempCell; 		// ID of cell with highest temperature
+
+	// 0x628h //
+
+	uint16_t packRes;			// resistance of entire pack
+	uint8_t  minRes;  			// resistance of lowest resistance cells
+	uint8_t  minResCell;         // ID of cell with lowest resistance
+	uint8_t  maxRes;				// resistance of highest resistance cells
+	uint8_t  maxResCell;			// ID of cell with highest resistance
+
+
+
+	// signed = 2's complement: 0XfFF = -1, 0x00 = 0, 0x01 = 1
+
+
+
+
+};
+
+BMS* BMS_new(int canMessageBaseID){
+
+	BMS* BMS_obj = (BMS*)malloc(sizeof(struct _BMS));
+	BMS_obj->canMessageBaseId = canMessageBaseID;
+	return BMS_obj;
+
+}
+
+
+
+/*
+ * TODO: change variables to VCU type variables
+ * TODO: move function below to caninput.c
+ *
+ * NOTE: MULTI-BYTE VALUES ARE BIG ENDIAN!
+ */
+void canInput_readMesagges(BMS* bms){
+	uint16_t utemp16;
+	int16_t  temp16;
+	uint32_t utemp32;
+
+case 0x622:
+
+	bms->state = canMessages[currMessage].data[0];
+	utemp16 = ((canMessages[currMessage].data[1] << 8) | (canMessages[currMessage].data[2]));
+	bms->timer = swap_uint16(temp);
+	bms->flags = canMessages[currMessage].data[3];
+	bms->faultCode = canMessages[currMessage].data[4];
+	bms->levelFaults = canMessages[currMessage].data[5];
+	bms->warnings = canMessages[currMessage].data[6]
+
+case 0x623:
+
+	utemp16 = ((canMessages[currMessage].data[0] << 8) | (canMessages[currMessage].data[1]));
+	bms->packVoltage = swap_uint16(temp);
+	bms->minVtg = canMessages[currMessage].data[2];
+	bms->minVtgCell = canMessages[currMessage].data[3];
+	bms->maxVtg = canMessages[currMessage].data[4];
+	bms->maxVtgCell = canMessages[currMessage].data[5];
+
+case 0x624:
+
+	temp16 = ((canMessages[currMessage].data[0] << 8) | (canMessages[currMessage].data[1]));
+	bms->packCurrent = swap_int16(temp16);
+
+	utemp16 = ((canMessages[currMessage].data[2] << 8) | (canMessages[currMessage].data[3]));
+	bms->chargeLimit  = swap_uint16(utemp16);
+
+	utemp16 = ((canMessages[currMessage].data[4] << 8) | (canMessages[currMessage].data[5]));
+	bms->dischargeLimit = swap_uint16(utemp16);
+
+case 0x625:
+
+	utemp32 = (((canMessages[currMessage].data[0] << 24) |
+			(canMessages[currMessage].data[1] << 16) |
+			(canMessages[currMessage].data[2] << 8)  |
+			(canMessages[currMessage].data[3])));
+	bms->batteryEnergyIn = swap_uint32(utemp32);
+
+	utemp32 = (((canMessages[currMessage].data[4] << 24) |
+			(canMessages[currMessage].data[5] << 16) |
+			(canMessages[currMessage].data[6] << 8)  |
+			(canMessages[currMessage].data[7])));
+	bms->batteryEnergyOut = swap_uint32(utemp32);
+
+case 0x626:
+
+	bms->SOC = canMessages[currMessage].data[0];
+
+	utemp16 = ((canMessages[currMessage].data[1] << 8) | (canMessages[currMessage].data[2]));
+	bms->DOD = swap_uint16(utemp16);
+
+	utemp16 = ((canMessages[currMessage].data[3] << 8) | (canMessages[currMessage].data[4]));
+	bms->capacity = swap_uint16(utemp16);
+
+	bms->SOH = canMessages[currMessage].data[6];
+
+
+case 0x627:
+
+	bms->packTemp = canMessages[currMessage].data[0];
+	bms->minTemp = canMessages[currMessage].data[2];
+	bms->minTempCell = canMessages[currMessage].data[3];
+	bms->maxTemp = canMessages[currMessage].data[4];
+	bms->maxTempCell canMessages[currMessage].data[5];
+
+case 0x628:
+
+	utemp16 = ((canMessages[currMessage].data[0] << 8) | (canMessages[currMessage].data[1]));
+	bms->packRes = swap_uint16(utemp16);
+
+	bms->minRes = canMessages[currMessage].data[2];
+	bms->minResCell = canMessages[currMessage].data[3];
+	bms->maxRes = canMessages[currMessage].data[4];
+	bms->maxResCell = canMessages[currMessage].data[5];
+
+}
+
+
+
+uint8_t swap_uint8(uint8_t val)
+{
+	return (val << 4) | (val >> 4);
+}
+
+int8_t swap_int8(int8_t val)
+{
+	return (val << 4) | (val >> 4);
+}
+uint16_t swap_uint16(uint16_t val)
+{
+	return (val << 8) | (val >> 8 );
+}
+
+//! Byte swap short
+int16_t swap_int16(int16_t val)
+{
+	return (val << 8) | ((val >> 8) & 0xFF);
+}
+
+//! Byte swap unsigned int
+uint32_t swap_uint32(uint32_t val)
+{
+	val = ((val << 8) & 0xFF00FF00 ) | ((val >> 8) & 0xFF00FF );
+	return (val << 16) | (val >> 16);
+}
+
+//! Byte swap int
+int32_t swap_int32(int32_t val)
+{
+	val = ((val << 8) & 0xFF00FF00) | ((val >> 8) & 0xFF00FF );
+	return (val << 16) | ((val >> 16) & 0xFFFF);
+}
+
+
+
+
+// ELITHION BMS OPTIONS //
+
+//uint8_t  updateState(BMS*);
+//uint16_t updateTimer();
+//uint8_t  updateFlags();
+//uint8_t  updateFaultCode();
+//uint8_t  updateLevelFaults();
+//
+//// PACK //
+//
+//uint16_t updatePackVoltage(); 	// volts
+//uint8_t  updateMinVtg(); 		// volts; individual cell voltage
+//uint8_t  updateMaxVtg();
+//uint8_t  updateMinVtgCell();
+//uint8_t  updateMaxVtgCell();
+//
+//// CURRENT //
+//
+//int16_t  updatePackCurrent(); 	 			// amps
+//uint16_t updateChargeLimit();				// 0-100 percent; returns EROR_READING_LIMIT_VALUE on error
+//uint16_t updateDischargeLimit();			// 0-100 percent; returns EROR_READING_LIMIT_VALUE on error
+//
+//uint8_t  updateSOC();			// Returns a value from 0-100
+//uint16_t updateDOD();		    // (Ah)
+//uint16_t updateCapacity();
+//uint8_t  updateSOH();
+//
+//// TEMP //
+//
+//int8_t  updatePackTemp();			// average pack temperature
+//int8_t  updateMinTemp();			    // Temperature of coldest sensor
+//int8_t  updateMinTempCell(); 		// ID of cell with lowest temperature
+//int8_t  updateMaxTemp();			    // Temperature of hottest sensor
+//int8_t  updateMaxTempCell(); 		// ID of cell with highest temperature
+//
+//uint16_t updatePackRes();				// resistance of entire pack
+//uint8_t  updateMinRes();  			// resistance of lowest resistance cells
+//uint8_t  updateMinResCell();          // ID of cell with lowest resistance
+//uint8_t  updateMaxRes();				// resistance of highest resistance cells
+//uint8_t  updateMaxResCell();			// ID of cell with highest resistance
+//
+//
+//LimitCause updateChargeLimitCause();
+//LimitCause updateDischargeLimitCause();
+//
+//
+////void getFaults(FaultOptions *presentFaults, StoredFault *storedFault, FaultOptions *presentWarnings);
+//void clearStoredFault();
+//
+//IOFlags getIOFlags();
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/bms.h
+++ b/bms.h
@@ -1,0 +1,157 @@
+#include <stdio.h>
+#include <stdint.h>
+
+
+#ifndef _BATTERYMANAGEMENTSYSTEM_H
+#define _BATTERYMANAGEMENTSYSTEM_H
+
+
+enum _FaultOptions
+{
+	DrivingOffWhilePluggedIn = 0x01,	// Driving off while plugged in
+	InterlockTripped = 0x02,			// Inter-lock is tripped
+	CommuncationFault = 0x04,			// Communication fault with a bank or cell
+	ChargeOverCurrent = 0x08,			// Charge over-current
+	DischargeOverCurrent = 0x10,        // Discharge over-current
+	OverTemperture = 0x20,				// Over-temperature fault
+	UnderVoltage = 0x40,				// Under voltage
+	OverVoltage = 0x80,					// Over voltage
+
+	// CUSTOM MESSAGES //
+
+	BMSNotDetected = 0x100,
+	InitFailed = 0x200,
+};
+typedef uint16_t FaultOptions; 			// FaultOptions is now a variable type -- uint16_t //
+
+
+enum _StoredFaults
+{
+	StoredNoFault = 0x0,						// No fault
+	StoredDrivingOffWhilePluggedIn = 0x01,		// Driving off while plugged in
+	StoredInterockTripped = 0x02,				// Interlock is tripped
+	StoredCommFault = 0x03,						// Communication fault with a bank or cell
+	StoredChargeOverCurrent = 0x04,				// Charge over-current
+	StoredDischargeOverCurrent = 0x05,			// Dishcarge over-current
+	StoredOverTemperture = 0x06,				// Over-temperature fault
+	StoredUnderVoltage = 0x07,					// Under voltage
+	StoredOverVoltage = 0x08,					// Over voltage
+
+	StoredNoBatteryVoltage = 0x09,              // No batter voltage
+	StoredHighVoltageBMinusLeak = 0xA,			// High voltage B- leak to chassis
+	StoredHighVoltageBPlusLeak = 0xB,			// High voltage B+ leak to chassis
+	StoredContactorK1Shorted = 0xC,				// Contactor K1 shorted
+	StoredContactorK2Shorted = 0xD,				// Contactor K2 shorted
+	StoredContactorK3Shorted = 0xE,				// Contactor K3 shorted
+	StoredNoPrecharge = 0xF,					// No precharge
+	StoredOpenK2 = 0x10,						// Open K2
+	StoredExcessivePrechargeTime = 0x11,		// Excessive precharge time
+	StoredEEPROMStackOverflow = 0x12,			// EEPROM stack overflow
+
+};
+
+typedef uint8_t StoredFault;
+
+enum _IOFlags{
+
+	/*
+	 * Using hex to represent each bit position
+	 */
+
+	IOFlagPowerFromSource = 0x01,				// There is power from the source
+	IOFlagPowerFromLoad = 0x02,					// There is power from the load
+	IOFlagInterlockedTripped = 0x04,			// The inter-lick is tripped
+	IOFlagHardWireContactorRequest = 0x08,		// There is a hard-wire contactor request
+	IOFlagCANContactorRequest = 0x10,			// There is a CAN contactor request
+	IOFlagHighLimitSet = 0x20,					// The HLIM is set
+	IOFlagLowLimitSet = 0x40,					// The LLIM is set
+	IOFlagFanIsOn = 0x80,						// The fan is on
+
+};
+
+typedef uint8_t IOFlags;
+
+
+enum _LimitCause{
+
+	LimitCauseErrorReadingValue = -1,
+	LimitCauseNone = 0,							// No limit
+	LimitCausePackVoltageTooLow,				// Pack voltage too low
+	LimitCausePackVolageTooHigh,				// Pack voltage too high
+	LimitCauseCellVoltageTooLow,				// Cell voltage too low
+	LimitCauseCellVoltageTooHigh,				// Cell voltage too high
+	LimitCauseTempTooHighToCharge,				// Temperature too high for charging
+	LimitCauseTempTooLowToCharge,				// Temperature too low for charging
+	LimitCauseTempTooHighToDischarge,			// Temperature too high for discharging
+	LimitCauseTempTooLowToDischarge,			// Temperature too low for discharging
+	LimitCauseChargingCurrentPeakTooLong,		// Charging current peak lasting too long
+	LimitCauseDischargingCurrentPeakTooLong,	// Discharging current peak lasted too long
+};
+
+typedef int8_t LimitCause;
+
+#define ERROR_READING_LIMIT_VALUE = -1
+
+
+
+
+
+
+typedef struct _BMS *BMS;
+
+	BMS newBMSObj();
+
+	// ELITHION BMS OPTIONS //
+
+	uint8_t getStateOfCharge();			// Returns a value from 0-100
+	uint16_t getDepthOfDischarge();		// (Ah)
+
+	LimitCause getChargeLimitCause();
+	LimitCause getDischargeLimitCause();
+
+	int8_t getChargeLimitValue(); 		// 0-100 percent; returns EROR_READING_LIMIT_VALUE on error
+	int8_t getDishargeLimitValue(); 	// 0-100 percent; returns EROR_READING_LIMIT_VALUE on error
+
+	// PACK //
+
+	float getPackVoltage(); 	// volts
+	float getMinVolage(); 		// volts; individual cell voltage
+	float getAvgVoltage();
+	float getMaxVoltage();
+	uint8_t getMinVoltageCellNumber();
+	uint8_t getAvgVoltageCellNumber();
+	uint8_t getMaxVoltageCellNUmber();
+
+	int getNumberOfCells();
+	float getVoltageForCell(int cell);
+
+	// CURRENT //
+
+	float getPackCurrent(); 	 			// amps
+	float getAverageSourceCurrent();		// amps
+	float getAverageLoadCurrent(); 			// amps
+	float getSourceCurrent(); 				// amps
+	float getLoadCurrent(); 				// amps
+
+	void getFaults(FaultOptions *presentFaults, StoredFault *storedFault, FaultOptions *presentWarnings);
+	void clearStoredFault();
+
+	IOFlags getIOFlags();
+
+
+
+#endif // _BATTERYMANAGEMENTSYSTEM_H
+
+//
+//	typedef struct _BatteryManagementSystem BatteryManagementSystem;
+//
+//	BatteryManagementSystem* bms_new(int canMessageBaseID); // initializing other variables?
+//
+//	void bms_updateFromCAN(int* CAN_Message);
+//	//
+//	// recieving message from CANinput function
+//	// taking message and im storing into variables so they can be used later and can be
+//	//
+
+
+

--- a/bms.h
+++ b/bms.h
@@ -1,3 +1,20 @@
+ /**************************************************************************
+ * 	REVISION HISTORY:
+ *
+ *
+ *	2016-4-6  - Rabeel Elahi - Added constructor and BMS data struct
+ *							 - Initially added helper functions to update variables,
+ *							   but decided to update variables by passing BMS pointer to
+ *							   canInput_readMesagges(BMS* bms). Commented out for future use.
+ *							 - Added functions to help with endian conversion.
+ *							   Possibly move to mathFunctions?
+ *
+ *	2016-3-28 - Rabeel Elahi - Created this file.
+ *
+ *
+ **************************************************************************/
+
+
 #include <stdio.h>
 #include <stdint.h>
 
@@ -5,8 +22,31 @@
 #ifndef _BATTERYMANAGEMENTSYSTEM_H
 #define _BATTERYMANAGEMENTSYSTEM_H
 
+typedef struct _BMS BMS;
 
-enum _FaultOptions
+BMS* BMS_new(int canMessageBaseID);
+
+/*
+ *  Functions for endian conversion
+ */
+uint8_t swap_uint8(uint8_t val);
+int8_t swap_int8(int8_t val);
+uint16_t swap_uint16(uint16_t val);
+int16_t swap_int16(int16_t val);
+uint32_t swap_uint32(uint32_t val);
+int32_t swap_int32(int32_t val);
+
+typedef enum
+{
+	relayFault = 0x08,
+	contactorK3Status = 0x04,
+	contactorK2Status = 0x02,
+	contactorK1Status = 0x01,
+	faultState = 0x00,
+
+} systemState;
+
+typedef enum
 {
 	DrivingOffWhilePluggedIn = 0x01,	// Driving off while plugged in
 	InterlockTripped = 0x02,			// Inter-lock is tripped
@@ -21,11 +61,12 @@ enum _FaultOptions
 
 	BMSNotDetected = 0x100,
 	InitFailed = 0x200,
-};
-typedef uint16_t FaultOptions; 			// FaultOptions is now a variable type -- uint16_t //
+
+} faultOptions;
 
 
-enum _StoredFaults
+
+typedef enum
 {
 	StoredNoFault = 0x0,						// No fault
 	StoredDrivingOffWhilePluggedIn = 0x01,		// Driving off while plugged in
@@ -37,7 +78,7 @@ enum _StoredFaults
 	StoredUnderVoltage = 0x07,					// Under voltage
 	StoredOverVoltage = 0x08,					// Over voltage
 
-	StoredNoBatteryVoltage = 0x09,              // No batter voltage
+	StoredNoBatteryVoltage = 0x09,              // No battery voltage
 	StoredHighVoltageBMinusLeak = 0xA,			// High voltage B- leak to chassis
 	StoredHighVoltageBPlusLeak = 0xB,			// High voltage B+ leak to chassis
 	StoredContactorK1Shorted = 0xC,				// Contactor K1 shorted
@@ -48,11 +89,11 @@ enum _StoredFaults
 	StoredExcessivePrechargeTime = 0x11,		// Excessive precharge time
 	StoredEEPROMStackOverflow = 0x12,			// EEPROM stack overflow
 
-};
+} storedFaults;
 
-typedef uint8_t StoredFault;
 
-enum _IOFlags{
+
+typedef enum {
 
 	/*
 	 * Using hex to represent each bit position
@@ -67,12 +108,12 @@ enum _IOFlags{
 	IOFlagLowLimitSet = 0x40,					// The LLIM is set
 	IOFlagFanIsOn = 0x80,						// The fan is on
 
-};
-
-typedef uint8_t IOFlags;
+} IOFlags;
 
 
-enum _LimitCause{
+
+
+typedef enum LimitCause{
 
 	LimitCauseErrorReadingValue = -1,
 	LimitCauseNone = 0,							// No limit
@@ -86,9 +127,8 @@ enum _LimitCause{
 	LimitCauseTempTooLowToDischarge,			// Temperature too low for discharging
 	LimitCauseChargingCurrentPeakTooLong,		// Charging current peak lasting too long
 	LimitCauseDischargingCurrentPeakTooLong,	// Discharging current peak lasted too long
-};
 
-typedef int8_t LimitCause;
+} LimitCause;
 
 #define ERROR_READING_LIMIT_VALUE = -1
 
@@ -97,61 +137,70 @@ typedef int8_t LimitCause;
 
 
 
-typedef struct _BMS *BMS;
+//
+//// ELITHION BMS OPTIONS //
+//
+//uint8_t  updateState();
+//uint16_t updateTimer();
+//uint8_t  updateFlags();
+//uint8_t  updateFaultCode();
+//uint8_t  updateLevelFaults();
+//
+//// PACK //
+//
+//uint16_t updatePackVoltage(); 	// volts
+//uint8_t  updateMinVtg(); 		// volts; individual cell voltage
+//uint8_t  updateMaxVtg();
+//uint8_t  updateMinVtgCell();
+//uint8_t  updateMaxVtgCell();
+//
+//
+//// CURRENT //
+//
+//int16_t  updatePackCurrent(); 	 			// amps
+//uint16_t updateChargeLimit();				// 0-100 percent; returns EROR_READING_LIMIT_VALUE on error
+//uint16_t updateDischargeLimit();			// 0-100 percent; returns EROR_READING_LIMIT_VALUE on error
+//
+//// BATTERY //
+//
+//uint32_t batteryEnergyIn();
+//uint32_t batteryEnergyOut();
+//
+//
+//uint8_t  updateSOC();
+//uint16_t updateDOD();
+//uint16_t updateCapacity();
+//uint8_t  updateSOH();
+//
+//// TEMP //
+//
+//int8_t  updatePackTemp();			     // average pack temperature
+//int8_t  updateMinTemp();			     // Temperature of coldest sensor
+//int8_t  updateMinTempCell(); 		     // ID of cell with lowest temperature
+//int8_t  updateMaxTemp();			     // Temperature of hottest sensor
+//int8_t  updateMaxTempCell(); 		     // ID of cell with highest temperature
+//
+//
+//// RESISTANCE //
+//
+//uint16_t updatePackRes();				// resistance of entire pack
+//uint8_t  updateMinRes();  			// resistance of lowest resistance cells
+//uint8_t  updateMinResCell();          // ID of cell with lowest resistance
+//uint8_t  updateMaxRes();				// resistance of highest resistance cells
+//uint8_t  updateMaxResCell();			// ID of cell with highest resistance
+//
+//LimitCause updateChargeLimitCause();
+//LimitCause updateDischargeLimitCause();
 
-	BMS newBMSObj();
-
-	// ELITHION BMS OPTIONS //
-
-	uint8_t getStateOfCharge();			// Returns a value from 0-100
-	uint16_t getDepthOfDischarge();		// (Ah)
-
-	LimitCause getChargeLimitCause();
-	LimitCause getDischargeLimitCause();
-
-	int8_t getChargeLimitValue(); 		// 0-100 percent; returns EROR_READING_LIMIT_VALUE on error
-	int8_t getDishargeLimitValue(); 	// 0-100 percent; returns EROR_READING_LIMIT_VALUE on error
-
-	// PACK //
-
-	float getPackVoltage(); 	// volts
-	float getMinVolage(); 		// volts; individual cell voltage
-	float getAvgVoltage();
-	float getMaxVoltage();
-	uint8_t getMinVoltageCellNumber();
-	uint8_t getAvgVoltageCellNumber();
-	uint8_t getMaxVoltageCellNUmber();
-
-	int getNumberOfCells();
-	float getVoltageForCell(int cell);
-
-	// CURRENT //
-
-	float getPackCurrent(); 	 			// amps
-	float getAverageSourceCurrent();		// amps
-	float getAverageLoadCurrent(); 			// amps
-	float getSourceCurrent(); 				// amps
-	float getLoadCurrent(); 				// amps
-
-	void getFaults(FaultOptions *presentFaults, StoredFault *storedFault, FaultOptions *presentWarnings);
-	void clearStoredFault();
-
-	IOFlags getIOFlags();
-
+//
+////void getFaults(FaultOptions *presentFaults, StoredFault *storedFault, FaultOptions *presentWarnings);
+//void clearStoredFault();
+//
+//IOFlags getIOFlags();
+//
 
 
 #endif // _BATTERYMANAGEMENTSYSTEM_H
-
-//
-//	typedef struct _BatteryManagementSystem BatteryManagementSystem;
-//
-//	BatteryManagementSystem* bms_new(int canMessageBaseID); // initializing other variables?
-//
-//	void bms_updateFromCAN(int* CAN_Message);
-//	//
-//	// recieving message from CANinput function
-//	// taking message and im storing into variables so they can be used later and can be
-//	//
 
 
 


### PR DESCRIPTION
The basic functionality of this code is to update a data structure of BMS variables. Namely, 0x622-0x28 which can be found [here](http://lithiumate.elithion.com/php/controller_can_specs.php).

A lot of bit manipulation is taking place to store separate data bytes into one variable. (e.g. charge limit data is in byte 2 & 3, which needs to stored into one int16_t)

Additionally, only **multi-byte** values are big endian as stated on their CAN specs page. Endian conversion functions are in place to help with that. 

Lastly, bms.h has some typedef enums and bms.c has some helper functions for updating variables both of which are not being used in the code, but are left there for future use possibly. 

See code revisions for more details. 